### PR TITLE
Dynamic icons

### DIFF
--- a/crates/eww/src/widgets/systray.rs
+++ b/crates/eww/src/widgets/systray.rs
@@ -166,6 +166,7 @@ impl Item {
         // updates
         let mut status_updates = item.sni.receive_new_status().await?;
         let mut title_updates = item.sni.receive_new_status().await?;
+        let mut icon_updates = item.sni.receive_new_icon().await?;
 
         loop {
             tokio::select! {
@@ -183,6 +184,10 @@ impl Item {
                 Some(_) = title_updates.next() => {
                     // set title
                     widget.set_tooltip_text(Some(&item.sni.title().await?));
+                }
+                Some(_) = icon_updates.next() => {
+                    // set icon
+                    icon.set_from_pixbuf(item.icon(*icon_size.borrow_and_update()).await.as_ref());
                 }
             }
         }

--- a/crates/notifier_host/src/dbus/dbus_status_notifier_item.rs
+++ b/crates/notifier_host/src/dbus/dbus_status_notifier_item.rs
@@ -69,7 +69,7 @@ trait StatusNotifierItem {
     fn category(&self) -> zbus::Result<String>;
 
     /// IconName property
-    #[dbus_proxy(property)]
+    #[dbus_proxy(property(emits_changed_signal = "false"))]
     fn icon_name(&self) -> zbus::Result<String>;
 
     /// IconPixmap property

--- a/crates/notifier_host/src/dbus/dbus_status_notifier_item.rs
+++ b/crates/notifier_host/src/dbus/dbus_status_notifier_item.rs
@@ -73,7 +73,7 @@ trait StatusNotifierItem {
     fn icon_name(&self) -> zbus::Result<String>;
 
     /// IconPixmap property
-    #[dbus_proxy(property)]
+    #[dbus_proxy(property(emits_changed_signal = "false"))]
     fn icon_pixmap(&self) -> zbus::Result<Vec<(i32, i32, Vec<u8>)>>;
 
     /// IconThemePath property


### PR DESCRIPTION
Hi!

This PR adds dynamically updating icons.

I also disabled caching for `IconName` as per https://dbus2.github.io/zbus/faq.html#why-arent-property-values-updating-for-my-service-that-doesnt-notify-changes, as otherwise some icons wouldn't update. Not sure if there's a better solution.

Little demo showing updates of `nm-applet` and `mullvad-vpn`:

[eww.webm](https://github.com/ralismark/eww/assets/3336264/958c64d8-0f85-44e1-8360-24c5c48629c2)
