### PR TITLE
fixup! feat: dynamic icons

### DIFF
--- a/crates/eww/src/widgets/systray.rs
+++ b/crates/eww/src/widgets/systray.rs
@@ -188,7 +188,7 @@ impl Item {
                 }
                 Some(_) = icon_updates.next() => {
                     // set icon
-                    icon.set_from_pixbuf(item.icon(*icon_size.borrow_and_update()).await.as_ref());
+                    load_icon_for_item(&icon, &item, *icon_size.borrow_and_update(), scale).await;
                 }
             }
         }


### PR DESCRIPTION
This fixes 218a4056e4e5b4232580daf675a4ba334865ed93 after 9e6f6a1cad41fb13beba4f36b5f46f77091350c3 due to api change